### PR TITLE
Add repo-specific examples to harmony guide

### DIFF
--- a/src/assets/docs/js-css-harmony-guide-en.md
+++ b/src/assets/docs/js-css-harmony-guide-en.md
@@ -1,0 +1,114 @@
+# Harmonizing JavaScript and CSS Styling
+
+This guide explains how to manipulate styling while keeping JavaScript and CSS working together without conflicts. It focuses on best practices for structuring code, using classes and variables, and ensuring maintainability.
+
+## 1. Keep Responsibilities Separate
+
+- **CSS** should handle visual styling such as layout, typography and colors.
+- **JavaScript** should handle behavior such as user interaction, data manipulation and dynamic content.
+- Avoid mixing inline style manipulations with complex logic. Instead, toggle classes or CSS custom properties from JavaScript.
+
+## 2. Use Consistent Naming Conventions
+
+- Follow a naming convention like BEM (Block__Element--Modifier) for classes.
+- Match JavaScript module names with the components they manipulate.
+- Use data attributes (e.g., `data-js="accordion"`) to connect JavaScript behaviors without polluting CSS class names.
+
+## 3. Create a Central Style Theme
+
+- Define CSS variables for common values like colors, spacing and fonts in a root or theme file.
+- Update variables through JavaScript to apply global changes (e.g., dark mode) instead of altering individual styles.
+
+```css
+:root {
+  --primary-color: #0069aa;
+  --gap-large: 2rem;
+}
+```
+
+```javascript
+function toggleDarkMode() {
+  document.documentElement.style.setProperty('--primary-color', '#ffffff');
+}
+```
+
+## 4. Manage State with Classes
+
+- Add or remove classes to trigger CSS transitions and animations.
+- Keep a set of utility classes (e.g., `.is-active`, `.is-hidden`) for common states.
+- Avoid setting style properties directly from JavaScript unless necessary.
+
+```javascript
+button.addEventListener('click', () => {
+  panel.classList.toggle('is-active');
+});
+```
+
+## 5. Avoid Style Conflicts
+
+- Use scoped selectors or component-specific wrappers to keep styles from leaking.
+- When dynamically injecting HTML, ensure that classes match existing CSS rules.
+- Document dependencies between JavaScript modules and CSS files in comments or documentation.
+
+## 6. Optimize for Performance
+
+- Batch DOM reads and writes to prevent layout thrashing.
+- Use `requestAnimationFrame` for high-frequency updates like animations.
+- Minify and bundle CSS and JavaScript for production to reduce load times.
+
+## 7. Testing and Debugging
+
+- Use browser devtools to inspect applied classes and styles.
+- Unit test JavaScript modules to verify that they apply the correct classes.
+- Manually test that style changes respond as expected in different browsers.
+
+## 8. Repo Specific Examples
+
+### Tuning the FAQ accordion
+
+The FAQ section uses `faq-toggle.js` from `src/bjarred-code/scripts/atomic-components/js-modules/components`. Styles live in `style.css` under `#vaccine-bjarred-app .faq-item`.
+Adjust the gradient or primary color with the CSS variables defined at the top of `style.css`:
+
+```css
+#vaccine-bjarred-app {
+  --grad-price-table: linear-gradient(145deg, #ffb347 0%, #ffcc33 60%, #ffdd55 100%);
+}
+```
+
+JavaScript lets you control the accordion programmatically:
+
+```javascript
+// Open the first FAQ item
+window.faqToggle.open('faq-0');
+
+// React to toggles
+document.addEventListener('vaccine:faq:toggled', (e) => {
+  console.log('FAQ toggled', e.detail);
+});
+```
+
+### Styling the responsive tables
+
+Tables are handled by `responsive-table.js` together with `vb-tables.css` and `table-responsive.css`.
+Colors come from variables like `--grad-price-table` and `--grad-location-table`.
+
+```css
+#vaccine-bjarred-app {
+  --grad-location-table: linear-gradient(to left, #ffe1a8 40%, #ffedd5 100%);
+}
+```
+
+To customize behavior you can create the component with options:
+
+```javascript
+window.tableComponent = new ResponsiveTable('.price-table', {
+  showScrollIndicators: false,
+  scrollSensitivity: 75
+});
+```
+
+These examples show how CSS variables and component APIs keep styling and behavior in sync.
+
+## Conclusion
+
+Maintaining harmony between JavaScript and CSS requires a clear separation of concerns, consistent conventions, and careful state management. By following these practices, you can build dynamic interfaces that remain easy to maintain and extend.

--- a/src/assets/docs/js-css-harmony-guide-sv.md
+++ b/src/assets/docs/js-css-harmony-guide-sv.md
@@ -1,0 +1,114 @@
+# Harmonisera JavaScript och CSS-styling
+
+Den här guiden beskriver hur du manipulerar stilar samtidigt som du behåller samspel mellan JavaScript och CSS. Här får du tips om struktur, klasser och variabler för att göra koden lätt att underhålla.
+
+## 1. Separera ansvar
+
+- **CSS** hanterar visuellt utseende som layout, typografi och färger.
+- **JavaScript** sköter beteende som interaktion, datamanipulering och dynamiskt innehåll.
+- Undvik att blanda inlinestilar med avancerad logik. Tillsätt eller ta bort klasser eller ändra CSS-variabler från JavaScript istället.
+
+## 2. Använd konsekventa namn
+
+- Följ en namngivningsstandard som BEM (Block__Element--Modifier) för klasser.
+- Matcha JavaScript-modulernas namn med komponenterna de styr.
+- Använd data-attribut (t.ex. `data-js="accordion"`) för att koppla beteende utan att röra CSS-klasserna.
+
+## 3. Skapa ett centralt teman
+
+- Definiera CSS-variabler för färger, avstånd och typsnitt i en rot- eller temafil.
+- Uppdatera variabler med JavaScript för globala ändringar (t.ex. mörkt läge) i stället för att ändra enstaka stilar.
+
+```css
+:root {
+  --primary-color: #0069aa;
+  --gap-large: 2rem;
+}
+```
+
+```javascript
+function toggleDarkMode() {
+  document.documentElement.style.setProperty('--primary-color', '#ffffff');
+}
+```
+
+## 4. Hantera tillstånd med klasser
+
+- Lägg till eller ta bort klasser för att trigga CSS-övergångar och animationer.
+- Håll ett set med hjälpsklasser (t.ex. `.is-active`, `.is-hidden`) för vanliga tillstånd.
+- Undvik att sätta stilar direkt via JavaScript om det inte behövs.
+
+```javascript
+button.addEventListener('click', () => {
+  panel.classList.toggle('is-active');
+});
+```
+
+## 5. Undvik stilkonflikter
+
+- Använd avgränsade selektorer eller komponent-specifika omslag för att hindra att stilar läcker.
+- Se till att dynamiskt genererad HTML har klasser som matchar befintliga regler.
+- Dokumentera beroenden mellan JavaScript-moduler och CSS-filer i kommentarer eller dokumentation.
+
+## 6. Optimera prestanda
+
+- Samla DOM-läsningar och skrivningar för att undvika layoutproblem.
+- Använd `requestAnimationFrame` för uppdateringar som sker ofta, exempelvis animationer.
+- Minimera och paketera CSS och JavaScript för produktion för snabbare laddning.
+
+## 7. Testa och felsök
+
+- Använd webbläsarens utvecklingsverktyg för att inspektera tillämpade klasser och stilar.
+- Enhetstesta JavaScript-moduler så att de lägger till rätt klasser.
+- Testa manuellt att stilförändringar fungerar i olika webbläsare.
+
+## 8. Exempel från projektet
+
+### Anpassa FAQ-accordion
+
+FAQ-delen styrs av `faq-toggle.js` i `src/bjarred-code/scripts/atomic-components/js-modules/components`. Stilarna finns i `style.css` under `#vaccine-bjarred-app .faq-item`.
+Ändra gradienten eller huvudfärgen med CSS-variablerna högst upp i `style.css`:
+
+```css
+#vaccine-bjarred-app {
+  --grad-price-table: linear-gradient(145deg, #ffb347 0%, #ffcc33 60%, #ffdd55 100%);
+}
+```
+
+JavaScript har publika metoder för att styra panelerna:
+
+```javascript
+// Öppna första FAQ-posten
+window.faqToggle.open('faq-0');
+
+// Lyssna på växlingar
+document.addEventListener('vaccine:faq:toggled', (e) => {
+  console.log('FAQ växlades', e.detail);
+});
+```
+
+### Styling av responsiva tabeller
+
+Tabellerna använder `responsive-table.js` tillsammans med `vb-tables.css` och `table-responsive.css`.
+Färger styrs av variabler som `--grad-price-table` och `--grad-location-table`.
+
+```css
+#vaccine-bjarred-app {
+  --grad-location-table: linear-gradient(to left, #ffe1a8 40%, #ffedd5 100%);
+}
+```
+
+Du kan även skicka in alternativ när komponenten initieras:
+
+```javascript
+window.tableComponent = new ResponsiveTable('.price-table', {
+  showScrollIndicators: false,
+  scrollSensitivity: 75
+});
+```
+
+Genom att dela variabler och API:er hålls JavaScript och CSS i synk.
+
+## Sammanfattning
+
+Genom att hålla isär ansvar, använda konsekventa konventioner och hantera tillstånd med klasser kan du skapa dynamiska gränssnitt där JavaScript och CSS samverkar utan konflikt.


### PR DESCRIPTION
## Summary
- update JS/CSS harmony guides with FAQ and table examples

## Testing
- `head src/assets/tests/faq-test.html | head`

------
https://chatgpt.com/codex/tasks/task_e_686e46c53b78833085dd12172df4847c